### PR TITLE
Avoid PageSpeed processing on binary responses

### DIFF
--- a/platform/packages/optimize/src/Http/Middleware/PageSpeed.php
+++ b/platform/packages/optimize/src/Http/Middleware/PageSpeed.php
@@ -17,10 +17,12 @@ abstract class PageSpeed
     {
         $response = $next($request);
 
+        $contentType = $response->headers->get('Content-Type');
+
         if (! OptimizerHelper::isEnabled()
             || $request->segment(1) == '_debugbar'
             || $request->expectsJson()
-            || in_array($response->headers->get('Content-Type'), ['application/json', 'application/pdf'])
+            || ($contentType && ! str_contains($contentType, 'text'))
             || $response instanceof BinaryFileResponse
             || $response instanceof StreamedResponse
         ) {


### PR DESCRIPTION
## Summary
- skip Optimize PageSpeed middleware when response is not textual to avoid binary file errors

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68af33a445bc832da3ca9e49803fbd19